### PR TITLE
feat: update MCP server for new API contract - route change to /subje…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,7 +1425,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sda-mcp-server"
-version = "0.2.4"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -37,15 +37,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -101,9 +101,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.1"
+version = "1.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.38.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -147,9 +147,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2797f34da339ce31042b27d23607e051786132987f595b02ba4f6a6dffb7030a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -201,9 +201,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.60"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a241312cea5059b13574bb9b3861cabf758b879c15190b37b6d6fd63ab6876"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -213,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -225,24 +225,24 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -525,9 +525,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -576,9 +576,9 @@ checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -590,7 +590,6 @@ dependencies = [
  "httparse",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -663,12 +662,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -689,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -703,15 +703,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -723,15 +723,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -787,9 +787,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -803,9 +803,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -816,7 +816,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -825,9 +825,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -841,10 +863,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -857,15 +881,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -921,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -950,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1008,16 +1032,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -1062,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -1282,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
@@ -1351,9 +1369,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1384,9 +1402,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -1569,12 +1587,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1698,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1708,9 +1726,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1723,9 +1741,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -1740,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1862,9 +1880,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -1968,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1981,23 +1999,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2005,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2018,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2040,9 +2054,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2376,15 +2390,15 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -2393,9 +2407,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2405,18 +2419,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.40"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2425,18 +2439,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2452,9 +2466,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -2463,9 +2477,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2474,9 +2488,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sda-mcp-server"
-version = "0.2.4"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/src/client.rs
+++ b/src/client.rs
@@ -286,7 +286,7 @@ impl SdaClient {
         per_page: Option<i64>,
         in_collection_id: Option<i32>,
     ) -> Result<ListSubjectsResponse> {
-        let url = format!("{}/api/v1/metadata-subjects", self.base_url);
+        let url = format!("{}/api/v1/subjects", self.base_url);
         let mut query = vec![];
 
         // Add language parameter
@@ -328,7 +328,7 @@ impl SdaClient {
 
     /// Creates a new metadata subject.
     pub async fn create_subject(&self, request: CreateSubjectRequest) -> Result<String> {
-        let url = format!("{}/api/v1/metadata-subjects", self.base_url);
+        let url = format!("{}/api/v1/subjects", self.base_url);
         let response = self
             .client
             .post(&url)
@@ -349,7 +349,7 @@ impl SdaClient {
 
     /// Deletes a metadata subject by its ID.
     pub async fn delete_subject(&self, id: i32, request: DeleteSubjectRequest) -> Result<()> {
-        let url = format!("{}/api/v1/metadata-subjects/{}", self.base_url, id);
+        let url = format!("{}/api/v1/subjects/{}", self.base_url, id);
         let response = self
             .client
             .delete(&url)
@@ -369,7 +369,7 @@ impl SdaClient {
         id: i32,
         request: UpdateSubjectRequest,
     ) -> Result<DublinMetadataSubjectResponse> {
-        let url = format!("{}/api/v1/metadata-subjects/{}", self.base_url, id);
+        let url = format!("{}/api/v1/subjects/{}", self.base_url, id);
         let response = self
             .client
             .put(&url)
@@ -394,7 +394,7 @@ impl SdaClient {
         id: i32,
         lang: MetadataLanguage,
     ) -> Result<DublinMetadataSubjectResponse> {
-        let url = format!("{}/api/v1/metadata-subjects/{}", self.base_url, id);
+        let url = format!("{}/api/v1/subjects/{}", self.base_url, id);
         let mut query = vec![];
 
         match lang {
@@ -1390,10 +1390,10 @@ mod tests {
             "test-key".to_string(),
         );
         let id = 42;
-        let expected_url = "https://api.example.com/api/v1/metadata-subjects/42";
+        let expected_url = "https://api.example.com/api/v1/subjects/42";
 
         // Test URL construction by checking format string
-        let constructed_url = format!("{}/api/v1/metadata-subjects/{}", client.base_url, id);
+        let constructed_url = format!("{}/api/v1/subjects/{}", client.base_url, id);
         assert_eq!(constructed_url, expected_url);
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -55,9 +55,9 @@ fn default_id() -> i64 {
 pub struct CreateAccessionCrawlArgs {
     /// The URL to crawl.
     pub url: String,
-    /// Language of the metadata.
+    /// Language of the metadata. Use "english" for English text, "arabic" for Arabic text.
     pub metadata_language: MetadataLanguage,
-    /// Title of the accession.
+    /// Title of the accession. Provide English text if metadata_language is "english", Arabic text if "arabic".
     pub metadata_title: String,
     /// Time period related to the accession (ISO 8601, e.g. "2026-02-01T00:00:00" - do NOT include the "Z" suffix).
     pub metadata_time: String,
@@ -70,36 +70,24 @@ pub struct CreateAccessionCrawlArgs {
     /// Optional browser profile for specific sites.
     #[serde(default)]
     pub browser_profile: Option<BrowserProfile>,
-    /// Description of the accession.
+    /// Description of the accession. Provide English text if metadata_language is "english", Arabic text if "arabic".
     #[serde(default)]
     pub metadata_description: Option<String>,
     /// Optional S3 filename.
     #[serde(default)]
     pub s3_filename: Option<String>,
-    /// List of contributor IDs (Arabic).
+    /// List of contributor IDs.
     #[serde(default)]
-    pub metadata_contributor_ar_ids: Vec<i32>,
-    /// List of contributor IDs (English).
+    pub metadata_contributor_ids: Vec<i32>,
+    /// List of contributor role IDs - must be 1:1 with contributors (same length).
     #[serde(default)]
-    pub metadata_contributor_en_ids: Vec<i32>,
-    /// List of contributor role IDs (Arabic) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_ar_ids: Vec<Option<i32>>,
-    /// List of contributor role IDs (English) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_en_ids: Vec<Option<i32>>,
-    /// Creator ID (Arabic).
+    pub metadata_contributor_role_ids: Vec<Option<i32>>,
+    /// Creator ID.
     #[serde(default = "default_id")]
-    pub metadata_creator_ar_id: i64,
-    /// Creator ID (English).
+    pub metadata_creator_id: i64,
+    /// Location ID.
     #[serde(default = "default_id")]
-    pub metadata_creator_en_id: i64,
-    /// Location ID (Arabic).
-    #[serde(default = "default_id")]
-    pub metadata_location_ar_id: i64,
-    /// Location ID (English).
-    #[serde(default = "default_id")]
-    pub metadata_location_en_id: i64,
+    pub metadata_location_id: i64,
     /// Whether to send email notification after crawl completes.
     #[serde(default)]
     pub send_email_notification: bool,
@@ -217,41 +205,29 @@ pub struct UpdateAccessionArgs {
     pub id: i32,
     /// Privacy status.
     pub is_private: bool,
-    /// Description of the accession.
+    /// Description of the accession. Provide English text if metadata_language is "english", Arabic text if "arabic".
     #[serde(default)]
     pub metadata_description: String,
-    /// Language of the metadata.
+    /// Language of the metadata. Use "english" for English text, "arabic" for Arabic text.
     pub metadata_language: MetadataLanguage,
     /// List of subject IDs.
     pub metadata_subjects: Vec<i32>,
     /// Time period related to the accession.
     pub metadata_time: String,
-    /// Title of the accession.
+    /// Title of the accession. Provide English text if metadata_language is "english", Arabic text if "arabic".
     pub metadata_title: String,
-    /// List of contributor IDs (Arabic).
+    /// List of contributor IDs.
     #[serde(default)]
-    pub metadata_contributor_ar_ids: Vec<i32>,
-    /// List of contributor IDs (English).
+    pub metadata_contributor_ids: Vec<i32>,
+    /// List of contributor role IDs - must be 1:1 with contributors (same length).
     #[serde(default)]
-    pub metadata_contributor_en_ids: Vec<i32>,
-    /// List of contributor role IDs (Arabic) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_ar_ids: Vec<Option<i32>>,
-    /// List of contributor role IDs (English) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_en_ids: Vec<Option<i32>>,
-    /// Creator ID (Arabic).
+    pub metadata_contributor_role_ids: Vec<Option<i32>>,
+    /// Creator ID.
     #[serde(default = "default_id")]
-    pub metadata_creator_ar_id: i64,
-    /// Creator ID (English).
+    pub metadata_creator_id: i64,
+    /// Location ID.
     #[serde(default = "default_id")]
-    pub metadata_creator_en_id: i64,
-    /// Location ID (Arabic).
-    #[serde(default = "default_id")]
-    pub metadata_location_ar_id: i64,
-    /// Location ID (English).
-    #[serde(default = "default_id")]
-    pub metadata_location_en_id: i64,
+    pub metadata_location_id: i64,
 }
 
 /// Arguments for creating a metadata subject.
@@ -291,7 +267,7 @@ pub struct UpdateAccessionRequest {
     /// Description of the accession.
     #[serde(default)]
     pub metadata_description: String,
-    /// Language of the metadata.
+    /// Language of the metadata. Use "english" for English text, "arabic" for Arabic text.
     pub metadata_language: MetadataLanguage,
     /// List of subject IDs.
     pub metadata_subjects: Vec<i32>,
@@ -299,26 +275,16 @@ pub struct UpdateAccessionRequest {
     pub metadata_time: String,
     /// Title of the accession.
     pub metadata_title: String,
-    /// List of contributor IDs (Arabic).
+    /// List of contributor IDs.
     #[serde(default)]
-    pub metadata_contributor_ar_ids: Vec<i32>,
-    /// List of contributor IDs (English).
+    pub metadata_contributor_ids: Vec<i32>,
+    /// List of contributor role IDs - must be 1:1 with contributors (same length).
     #[serde(default)]
-    pub metadata_contributor_en_ids: Vec<i32>,
-    /// List of contributor role IDs (Arabic) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_ar_ids: Vec<Option<i32>>,
-    /// List of contributor role IDs (English) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_en_ids: Vec<Option<i32>>,
-    /// Creator ID (Arabic).
-    pub metadata_creator_ar_id: Option<i64>,
-    /// Creator ID (English).
-    pub metadata_creator_en_id: Option<i64>,
-    /// Location ID (Arabic).
-    pub metadata_location_ar_id: Option<i64>,
-    /// Location ID (English).
-    pub metadata_location_en_id: Option<i64>,
+    pub metadata_contributor_role_ids: Vec<Option<i32>>,
+    /// Creator ID.
+    pub metadata_creator_id: Option<i64>,
+    /// Location ID.
+    pub metadata_location_id: Option<i64>,
 }
 
 /// Request body for creating a metadata subject.
@@ -351,9 +317,9 @@ pub struct UpdateSubjectRequest {
 pub struct CreateAccessionCrawlRequest {
     /// The URL to crawl.
     pub url: String,
-    /// Language of the metadata.
+    /// Language of the metadata. Use "english" for English text, "arabic" for Arabic text.
     pub metadata_language: MetadataLanguage,
-    /// Title of the accession.
+    /// Title of the accession. Provide English text if metadata_language is "english", Arabic text if "arabic".
     pub metadata_title: String,
     /// Time period related to the accession (ISO 8601).
     pub metadata_time: String,
@@ -366,32 +332,22 @@ pub struct CreateAccessionCrawlRequest {
     /// Optional browser profile for specific sites.
     #[serde(default)]
     pub browser_profile: Option<BrowserProfile>,
-    /// Description of the accession.
+    /// Description of the accession. Provide English text if metadata_language is "english", Arabic text if "arabic".
     #[serde(default)]
     pub metadata_description: Option<String>,
     /// Optional S3 filename.
     #[serde(default)]
     pub s3_filename: Option<String>,
-    /// List of contributor IDs (Arabic).
+    /// List of contributor IDs.
     #[serde(default)]
-    pub metadata_contributor_ar_ids: Vec<i32>,
-    /// List of contributor IDs (English).
+    pub metadata_contributor_ids: Vec<i32>,
+    /// List of contributor role IDs - must be 1:1 with contributors (same length).
     #[serde(default)]
-    pub metadata_contributor_en_ids: Vec<i32>,
-    /// List of contributor role IDs (Arabic) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_ar_ids: Vec<Option<i32>>,
-    /// List of contributor role IDs (English) - must be 1:1 with contributors.
-    #[serde(default)]
-    pub metadata_contributor_role_en_ids: Vec<Option<i32>>,
-    /// Creator ID (Arabic).
-    pub metadata_creator_ar_id: Option<i64>,
-    /// Creator ID (English).
-    pub metadata_creator_en_id: Option<i64>,
-    /// Location ID (Arabic).
-    pub metadata_location_ar_id: Option<i64>,
-    /// Location ID (English).
-    pub metadata_location_en_id: Option<i64>,
+    pub metadata_contributor_role_ids: Vec<Option<i32>>,
+    /// Creator ID.
+    pub metadata_creator_id: Option<i64>,
+    /// Location ID.
+    pub metadata_location_id: Option<i64>,
     /// Whether to send email notification after crawl completes.
     #[serde(default)]
     pub send_email_notification: bool,

--- a/src/server.rs
+++ b/src/server.rs
@@ -140,13 +140,13 @@ impl SdaServer {
 
     /// Updates an existing accession.
     ///
-    /// Important: The `metadata_language` field determines which language's metadata is being updated.
-    /// - When `metadata_language` is "english": use `metadata_title` for English title, `metadata_description` for English description
-    /// - When `metadata_language` is "arabic": use `metadata_title` for Arabic title (provide Arabic text), `metadata_description` for Arabic description
+    /// **Important Language Convention:**
+    /// - When `metadata_language` is `"english"`: provide English text in `metadata_title` and `metadata_description`
+    /// - When `metadata_language` is `"arabic"`: provide Arabic text in `metadata_title` and `metadata_description`
     ///
-    /// The `metadata_title` and `metadata_description` fields will only update the language matching `metadata_language`.
+    /// The API uses `metadata_language` to determine which language's metadata you're updating.
     #[tool(
-        description = "Update an accession. Note: contributor_role_ids must be 1:1 with contributor_ids (same length). The metadata_language field determines which language's title and description are being updated - when set to english, provide English text in metadata_title/metadata_description; when set to arabic, provide Arabic text in those fields."
+        description = "Update an accession. Note: contributor_role_ids must be 1:1 with contributor_ids (same length). **Important:** The metadata_language field determines which language's title and description are being updated - when set to english, provide English text in metadata_title/metadata_description; when set to arabic, provide Arabic text in those fields."
     )]
     async fn update_accession(
         &self,
@@ -160,14 +160,10 @@ impl SdaServer {
             metadata_subjects: args.metadata_subjects,
             metadata_time: args.metadata_time,
             metadata_title: args.metadata_title,
-            metadata_contributor_ar_ids: args.metadata_contributor_ar_ids,
-            metadata_contributor_en_ids: args.metadata_contributor_en_ids,
-            metadata_contributor_role_ar_ids: args.metadata_contributor_role_ar_ids,
-            metadata_contributor_role_en_ids: args.metadata_contributor_role_en_ids,
-            metadata_creator_ar_id: opt_id(args.metadata_creator_ar_id),
-            metadata_creator_en_id: opt_id(args.metadata_creator_en_id),
-            metadata_location_ar_id: opt_id(args.metadata_location_ar_id),
-            metadata_location_en_id: opt_id(args.metadata_location_en_id),
+            metadata_contributor_ids: args.metadata_contributor_ids,
+            metadata_contributor_role_ids: args.metadata_contributor_role_ids,
+            metadata_creator_id: opt_id(args.metadata_creator_id),
+            metadata_location_id: opt_id(args.metadata_location_id),
         };
         let response = self
             .client
@@ -183,11 +179,11 @@ impl SdaServer {
 
     /// Creates a new accession by crawling a URL.
     ///
-    /// Important: The `metadata_language` field determines which language's metadata is being created.
-    /// - When `metadata_language` is "english": provide English text in `metadata_title` and `metadata_description`
-    /// - When `metadata_language` is "arabic": provide Arabic text in `metadata_title` and `metadata_description`
+    /// **Important Language Convention:**
+    /// - When `metadata_language` is `"english"`: provide English text in `metadata_title` and `metadata_description`
+    /// - When `metadata_language` is `"arabic"`: provide Arabic text in `metadata_title` and `metadata_description`
     #[tool(
-        description = "Create a new accession (crawl). Note: metadata_time must be in ISO 8601 format without timezone (e.g., '2026-02-01T00:00:00', not '2026-02-01T00:00:00Z'). Contributor role IDs must be 1:1 with contributor IDs (same length). The metadata_language field determines which language's title and description are being created - when set to english, provide English text; when set to arabic, provide Arabic text."
+        description = "Create a new accession (crawl). Note: metadata_time must be in ISO 8601 format without timezone (e.g., '2026-02-01T00:00:00', not '2026-02-01T00:00:00Z'). Contributor role IDs must be 1:1 with contributor IDs (same length). **Important:** The metadata_language field determines which language's title and description are being created - when set to english, provide English text; when set to arabic, provide Arabic text."
     )]
     async fn create_accession_crawl(
         &self,
@@ -205,14 +201,10 @@ impl SdaServer {
             browser_profile: args.browser_profile,
             metadata_description: args.metadata_description,
             s3_filename: args.s3_filename,
-            metadata_contributor_ar_ids: args.metadata_contributor_ar_ids,
-            metadata_contributor_en_ids: args.metadata_contributor_en_ids,
-            metadata_contributor_role_ar_ids: args.metadata_contributor_role_ar_ids,
-            metadata_contributor_role_en_ids: args.metadata_contributor_role_en_ids,
-            metadata_creator_ar_id: opt_id(args.metadata_creator_ar_id),
-            metadata_creator_en_id: opt_id(args.metadata_creator_en_id),
-            metadata_location_ar_id: opt_id(args.metadata_location_ar_id),
-            metadata_location_en_id: opt_id(args.metadata_location_en_id),
+            metadata_contributor_ids: args.metadata_contributor_ids,
+            metadata_contributor_role_ids: args.metadata_contributor_role_ids,
+            metadata_creator_id: opt_id(args.metadata_creator_id),
+            metadata_location_id: opt_id(args.metadata_location_id),
             send_email_notification: args.send_email_notification,
         };
         let response = self
@@ -226,7 +218,13 @@ impl SdaServer {
     }
 
     /// Lists metadata subjects available in the archive.
-    #[tool(description = "List subjects")]
+    ///
+    /// **Important:** Use the `lang` parameter to specify which language's subjects to retrieve:
+    /// - `lang: "english"` returns English subjects
+    /// - `lang: "arabic"` returns Arabic subjects
+    #[tool(
+        description = "List subjects. Use the lang parameter to specify 'english' or 'arabic' to get subjects in that language."
+    )]
     async fn list_subjects(
         &self,
         Parameters(args): Parameters<ListSubjectsArgs>,


### PR DESCRIPTION
…cts and simplified language model

BREAKING: Removed _ar/_en suffix fields from accession args, now uses single fields + metadata_language to determine which language is being updated.

- Changed subjects route from /api/v1/metadata-subjects to /api/v1/subjects
- Simplified model: metadata_creator_id, metadata_location_id, metadata_contributor_ids, metadata_contributor_role_ids (no more _ar/_en)
- Added explicit documentation about language convention in tool descriptions
- Bumped version to 0.3.0